### PR TITLE
[#7] feature : always keep latest version of mips-simulator-js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@types/node": "^16.18.11",
         "@types/react": "^18.0.26",
         "@types/react-dom": "^18.0.10",
-        "mips-simulator-js": "^1.0.1",
+        "mips-simulator-js": "latest",
         "node-sass": "^8.0.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -12622,9 +12622,9 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/mips-simulator-js": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/mips-simulator-js/-/mips-simulator-js-1.0.1.tgz",
-      "integrity": "sha512-BwkWuPQFUny8Ua+laWMbEFkHMbi3GYRV98rKMAThsW1hxR8zP/gR35HGBsdnUuJvtQYXmc0GimtGGsF5f7cp1Q==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/mips-simulator-js/-/mips-simulator-js-2.0.2.tgz",
+      "integrity": "sha512-mtOb2Pui5wK/9VdHoVn1zYsPwcBkXcNMakJYNzq8ddiiUM/hUPVdsnx0Fxb4LwiUNap4OpgefsCQAIce8q/Tzg==",
       "dependencies": {
         "ts-node": "^10.9.1"
       }
@@ -27744,9 +27744,9 @@
       }
     },
     "mips-simulator-js": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/mips-simulator-js/-/mips-simulator-js-1.0.1.tgz",
-      "integrity": "sha512-BwkWuPQFUny8Ua+laWMbEFkHMbi3GYRV98rKMAThsW1hxR8zP/gR35HGBsdnUuJvtQYXmc0GimtGGsF5f7cp1Q==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/mips-simulator-js/-/mips-simulator-js-2.0.2.tgz",
+      "integrity": "sha512-mtOb2Pui5wK/9VdHoVn1zYsPwcBkXcNMakJYNzq8ddiiUM/hUPVdsnx0Fxb4LwiUNap4OpgefsCQAIce8q/Tzg==",
       "requires": {
         "ts-node": "^10.9.1"
       }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@types/node": "^16.18.11",
     "@types/react": "^18.0.26",
     "@types/react-dom": "^18.0.10",
-    "mips-simulator-js": "^1.0.1",
+    "mips-simulator-js": "latest",
     "node-sass": "^8.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6962,10 +6962,10 @@
     "minipass" "^3.0.0"
     "yallist" "^4.0.0"
 
-"mips-simulator-js@^1.0.1":
-  "integrity" "sha512-BwkWuPQFUny8Ua+laWMbEFkHMbi3GYRV98rKMAThsW1hxR8zP/gR35HGBsdnUuJvtQYXmc0GimtGGsF5f7cp1Q=="
-  "resolved" "https://registry.npmjs.org/mips-simulator-js/-/mips-simulator-js-1.0.1.tgz"
-  "version" "1.0.1"
+"mips-simulator-js@latest":
+  "integrity" "sha512-mtOb2Pui5wK/9VdHoVn1zYsPwcBkXcNMakJYNzq8ddiiUM/hUPVdsnx0Fxb4LwiUNap4OpgefsCQAIce8q/Tzg=="
+  "resolved" "https://registry.npmjs.org/mips-simulator-js/-/mips-simulator-js-2.0.2.tgz"
+  "version" "2.0.2"
   dependencies:
     "ts-node" "^10.9.1"
 


### PR DESCRIPTION
## ISSUE <#7> {simulator Package version}
여기에 이슈에 대해서 간단하게 설명해주세요
mips-simulator-js 버전 항상 최신상태로 유지

<br>

## CHANGES
어떤 코드를 만들었는지 혹은 어떤 코드를 수정해서 문제를 해결했는지 적어주세요
mips-simulator-js 버전 항상 최신상태로 설치 되도록 변경


<br>

## TEST
어떤 부분을 테스트 해보면 좋을지 어떻게 테스트하면 되는지 간단하게 설명해주세요
`npm update mips-simulator-js`
로 mips-simulator-js가 잘 업데이트 되는지 확인해주세요.

## FYI
이미 설치되어 있는 패키지의 경우, latest로 표시해놓아도 `npm install` 만 했을때는 업데이트가 되지 않는다.
`npm update mips-simulator-js` 이 커맨드로 따로 업데이트 해주시길 바랍니다!
