### PR TITLE
[#27] FIX: simulator 내 AssembleFilePanel 에러 수정

### DIFF
--- a/src/components/common/ClickablePanel.tsx
+++ b/src/components/common/ClickablePanel.tsx
@@ -86,7 +86,7 @@ const ClickablePanel = ({
   data: string[];
   highlightColor: string;
   width: string;
-  height:string;
+  height: string;
   type: string;
 }) => {
   const [, setHighlightNumbers] = useRecoilState(assemblyExecutedLine);
@@ -137,7 +137,7 @@ const ClickablePanel = ({
   };
 
   return (
-    <PanelDisplay width={width} height={height} >
+    <PanelDisplay width={width} height={height}>
       <PanelBody>
         {data.map((ele, index) => {
           return (
@@ -153,7 +153,9 @@ const ClickablePanel = ({
                 <HighlightedText
                   isHighlighted={highlightNumbers.includes(index)}
                   isHovered={
-                    type === "assembly"
+                    type === "simulator"
+                      ? false
+                      : type === "assembly"
                       ? assemblyHoveringNum?.includes(index)
                       : binaryHoveringNum?.includes(index)
                   }

--- a/src/components/simulator/AssembleFilePanel.tsx
+++ b/src/components/simulator/AssembleFilePanel.tsx
@@ -1,14 +1,14 @@
-import {useEffect, useState} from "react";
-import {useRecoilState, useRecoilValue} from "recoil";
+import { useEffect, useState } from "react";
+import { useRecoilState, useRecoilValue } from "recoil";
 import {
   selectedAssemblyFileState,
   selectedFileContentState,
 } from "../../recoil/state";
 import TopTab from "../common/TopTab";
 import ClickablePanel from "../common/ClickablePanel";
-import {HL_ORANGE} from "../../styles/color";
+import { HL_ORANGE } from "../../styles/color";
 
-const AssembleFilePanel = ({highlighted}: {highlighted: number | null}) => {
+const AssembleFilePanel = ({ highlighted }: { highlighted: number | null }) => {
   const selectedAssemblyFile = useRecoilValue(selectedAssemblyFileState);
   const [fileContent, setFileContent] = useRecoilState(
     selectedFileContentState
@@ -36,7 +36,7 @@ const AssembleFilePanel = ({highlighted}: {highlighted: number | null}) => {
   }, [highlighted]);
 
   return (
-    <div style={{flexDirection: "row"}}>
+    <div style={{ flexDirection: "row" }}>
       <TopTab title={selectedAssemblyFile} isBinary={false} />
       <ClickablePanel
         highlightNumbers={highlightedList}
@@ -44,7 +44,7 @@ const AssembleFilePanel = ({highlighted}: {highlighted: number | null}) => {
         highlightColor={HL_ORANGE}
         width={"420px"}
         height={"740px"}
-        type={"assembly"}
+        type={"simulator"}
       />
     </div>
   );

--- a/src/components/simulator/AssembleFilePanel.tsx
+++ b/src/components/simulator/AssembleFilePanel.tsx
@@ -1,20 +1,19 @@
-import { useEffect } from "react";
-import { useRecoilState, useRecoilValue } from "recoil";
+import {useEffect, useState} from "react";
+import {useRecoilState, useRecoilValue} from "recoil";
 import {
-  assemblyExecutedLine,
   selectedAssemblyFileState,
   selectedFileContentState,
 } from "../../recoil/state";
 import TopTab from "../common/TopTab";
 import ClickablePanel from "../common/ClickablePanel";
-import { HL_ORANGE } from "../../styles/color";
+import {HL_ORANGE} from "../../styles/color";
 
-const AssembleFilePanel = () => {
+const AssembleFilePanel = ({highlighted}: {highlighted: number | null}) => {
   const selectedAssemblyFile = useRecoilValue(selectedAssemblyFileState);
   const [fileContent, setFileContent] = useRecoilState(
     selectedFileContentState
   );
-  const highlightNumbers = useRecoilValue(assemblyExecutedLine);
+  const [highlightedList, setHighlightedList] = useState<number[]>([]);
 
   useEffect(() => {
     const fetchFile = async (filePath: string) => {
@@ -28,11 +27,19 @@ const AssembleFilePanel = () => {
     fetchFile(filePath);
   }, [selectedAssemblyFile, setFileContent]);
 
+  useEffect(() => {
+    const newHighlighted: number[] = [];
+    if (highlighted) {
+      newHighlighted.push(highlighted);
+    }
+    setHighlightedList(newHighlighted);
+  }, [highlighted]);
+
   return (
-    <div style={{ flexDirection: "row" }}>
+    <div style={{flexDirection: "row"}}>
       <TopTab title={selectedAssemblyFile} isBinary={false} />
       <ClickablePanel
-        highlightNumbers={highlightNumbers}
+        highlightNumbers={highlightedList}
         data={fileContent ? fileContent : []}
         highlightColor={HL_ORANGE}
         width={"420px"}

--- a/src/pages/Simulator.tsx
+++ b/src/pages/Simulator.tsx
@@ -1,9 +1,9 @@
-import { useEffect, useState } from "react";
-import { useRecoilValue } from "recoil";
-import { IMapDetail, selectedFileContentState } from "../recoil/state";
-import { assemble, simulator } from "mips-simulator-js";
-import { SimulatorBody } from "../styles/theme";
-import { simulatorOutputType } from "mips-simulator-js/dist/src/utils/functions";
+import {useEffect, useState} from "react";
+import {useRecoilValue} from "recoil";
+import {IMapDetail, selectedFileContentState} from "../recoil/state";
+import {assemble, simulator} from "mips-simulator-js";
+import {SimulatorBody} from "../styles/theme";
+import {simulatorOutputType} from "mips-simulator-js/dist/src/utils/functions";
 
 import AssembleFilePanel from "../components/simulator/AssembleFilePanel";
 import FileSelector from "../components/common/FileSelector";
@@ -13,12 +13,13 @@ import DataStackPanel from "../components/simulator/DataStackPanel";
 import ControlBar from "../components/common/ControlBar";
 
 export interface instructionSet {
+  key: number | null;
   assembly: string;
   binary: string;
 }
 
-const NULL_STATE = { PC: "", registers: {}, dataSection: {}, stackSection: {} };
-const NULL_INSTR = { assembly: "", binary: "" };
+const NULL_STATE = {PC: "", registers: {}, dataSection: {}, stackSection: {}};
+const NULL_INSTR = {key: null, assembly: "", binary: ""};
 
 const getInstr = (
   pc: number,
@@ -33,6 +34,7 @@ const getInstr = (
       for (let binary of instr.binary) {
         if (binary.lineNumber === lineNumber) {
           return {
+            key: instr.key,
             assembly: instr.assembly.trim(),
             binary: binary.data,
           };
@@ -62,8 +64,8 @@ const Simulator = () => {
 
   const fetchSimulator = async (fileContent: string[] | null) => {
     if (fileContent) {
-      const { mappingDetail } = await assemble(fileContent, true);
-      const { result, history } = await simulator(fileContent, 1000, true);
+      const {mappingDetail} = await assemble(fileContent, true);
+      const {result, history} = await simulator(fileContent, 1000, true);
 
       setMappingTable(mappingDetail);
       setResultState(result);
@@ -107,7 +109,7 @@ const Simulator = () => {
   return (
     <SimulatorBody>
       <FileSelector />
-      <AssembleFilePanel />
+      <AssembleFilePanel highlighted={instr ? instr.key : null} />
       <RegisterPanel
         register={curState ? curState.registers : []}
         prev={prevState ? prevState.registers : []}


### PR DESCRIPTION
Simulator 화면 내에 AssembleFilePanel의 highlight가 이상하게 동작하던 것을 수정

## ISSUE <#27> Simulator내 AssembleFilePanel 하이라이트 이슈
Simulator 화면 내에 AssembleFilePanel의 highlight가 이상하게 동작하던 것을 수정


<br>

## CHANGES
simulator에서 실행되고 있는 명령어의 key값 추가
AssembleFIlePanel에서 key값 받아서 highlighted List에 추가

<br>

## TEST
npm start 이후 simulator 화면에서 테스트 진행

## EX
예시 사진이 있다면 여기에 첨부해주세요
