### PR TITLE
[#30] FIX: simulator assembleFilePanel hover시 오류 수정

### DIFF
--- a/src/components/common/ClickablePanel.tsx
+++ b/src/components/common/ClickablePanel.tsx
@@ -1,4 +1,4 @@
-import { useRecoilState, useRecoilValue } from "recoil";
+import {useRecoilState, useRecoilValue} from "recoil";
 import {
   IMapDetail,
   assemblyExecutedLine,
@@ -66,7 +66,7 @@ const getHoverInfo = (
       (index) => (assemblyInstruction += mappingTable[index]["assembly"])
     );
 
-    return type === "assembly"
+    return type === "assembly" || type === "simulator"
       ? mappingTable[assemblyLineNum]["binary"][0]["data"]
       : assemblyInstruction;
   } else {

--- a/src/pages/Assembler.tsx
+++ b/src/pages/Assembler.tsx
@@ -1,5 +1,5 @@
-import React, { useCallback, useEffect, useState } from "react";
-import { useRecoilState, useRecoilValue } from "recoil";
+import React, {useCallback, useEffect, useState} from "react";
+import {useRecoilState, useRecoilValue} from "recoil";
 import {
   assemblyExecutedLine,
   binaryInstructionsOutput,
@@ -7,8 +7,8 @@ import {
   selectedFileContentState,
   selectedAssemblyFileState,
 } from "../recoil/state";
-import { AssemblerBody } from "../styles/theme";
-import { assemble } from "mips-simulator-js";
+import {AssemblerBody} from "../styles/theme";
+import {assemble} from "mips-simulator-js";
 import AssembleFilePanel from "../components/assembler/AssembleFilePanel";
 import BinaryFilePanel from "../components/assembler/BinaryFilePanel";
 import FileSelector from "../components/common/FileSelector";
@@ -40,7 +40,7 @@ const Assembler = () => {
 
   const saveOutput = useCallback(() => {
     if (fileContent) {
-      const { output: binaryList, mappingDetail } = assemble(fileContent, true);
+      const {output: binaryList, mappingDetail} = assemble(fileContent, true);
       setBinaryInstructions(binaryList);
       setMappingTable(mappingDetail);
     }


### PR DESCRIPTION
assembleFilePanel에 마우스 hover시 잘못된 명령어가 추가설명에 뜨던 오류를 수정 원인은 useRecoilState를 쓰지 않고 useState를 써서 ClickablePanel에서 제대로 된 MappingTable을 전달 받지 못했기 때문

## ISSUE <#30> {simulator assembleFilePanel hover시 오류 수정}
assembleFilePanel에 마우스 hover시 잘못된 명령어가 추가설명에 뜨던 오류


<br>

## CHANGES
simulator.tsx에서 useState로 선언되어 있던 mappingTable을 useRecoilState로 선언해서 전역 변수로 사용하도록 변경


<br>

## TEST
어떤 부분을 테스트 해보면 좋을지 어떻게 테스트하면 되는지 간단하게 설명해주세요

## EX
예시 사진이 있다면 여기에 첨부해주세요
