### PR TITLE
[#33] feat: 상황별 마우스 오버 시 모양 변경

### DIFF
--- a/src/components/common/ControlBar.tsx
+++ b/src/components/common/ControlBar.tsx
@@ -25,7 +25,12 @@ const ControlBar = ({
         <NoneDragImg
           src={draggableIcon}
           alt={"draggable"}
-          style={{width: "15px", height: "24px", marginLeft: "4px"}}
+          style={{
+            width: "15px",
+            height: "24px",
+            marginLeft: "4px",
+            cursor: "pointer",
+          }}
         />
         <BarText>CYCLE: {cycle}</BarText>
         <CenterAlign onClick={handleCounterPrevious}>

--- a/src/components/common/TopTab.tsx
+++ b/src/components/common/TopTab.tsx
@@ -1,22 +1,22 @@
-import React, { useState } from "react";
-import { useRecoilState, useRecoilValue } from "recoil";
+import React, {useState} from "react";
+import {useRecoilState, useRecoilValue} from "recoil";
 import {
   assemblyExecutedLine,
   selectedFileContentState,
 } from "../../recoil/state";
 
-import { PanelTitle } from "../../styles/panelStyle";
+import {PanelTitle} from "../../styles/panelStyle";
 import playIcon from "../../assets/icons/play.png";
 import resetIcon from "../../assets/icons/reset.png";
 
-const TopTab = ({ title, isBinary }: { title: string; isBinary: boolean }) => {
+const TopTab = ({title, isBinary}: {title: string; isBinary: boolean}) => {
   const [, setHighlightNumbers] = useRecoilState(assemblyExecutedLine);
   const fileContent = useRecoilValue(selectedFileContentState);
 
-  const [isHovering, setIsHovering] = useState({ reset: false, play: false });
+  const [isHovering, setIsHovering] = useState({reset: false, play: false});
 
   return (
-    <div style={{ display: "flex", justifyContent: "space-between" }}>
+    <div style={{display: "flex", justifyContent: "space-between"}}>
       <PanelTitle>{title}</PanelTitle>
 
       {isBinary && (
@@ -34,9 +34,10 @@ const TopTab = ({ title, isBinary }: { title: string; isBinary: boolean }) => {
               width: isHovering.reset ? "24px" : "20px",
               height: isHovering.reset ? "28px" : "24px",
               marginRight: "15px",
+              cursor: "pointer",
             }}
-            onMouseOver={() => setIsHovering({ reset: true, play: false })}
-            onMouseOut={() => setIsHovering({ reset: false, play: false })}
+            onMouseOver={() => setIsHovering({reset: true, play: false})}
+            onMouseOut={() => setIsHovering({reset: false, play: false})}
           />
           <img
             src={playIcon}
@@ -48,12 +49,13 @@ const TopTab = ({ title, isBinary }: { title: string; isBinary: boolean }) => {
                   : [preValues[0] + 1]
               );
             }}
-            onMouseOver={() => setIsHovering({ reset: false, play: true })}
-            onMouseOut={() => setIsHovering({ reset: false, play: false })}
+            onMouseOver={() => setIsHovering({reset: false, play: true})}
+            onMouseOut={() => setIsHovering({reset: false, play: false})}
             style={{
               width: isHovering.play ? "20px" : "16px",
               height: isHovering.play ? "22px" : "18px",
               marginRight: "20px",
+              cursor: "pointer",
             }}
           />
         </div>

--- a/src/styles/barStyle.ts
+++ b/src/styles/barStyle.ts
@@ -32,4 +32,5 @@ export const BarIcon = styled(NoneDragImg)`
   height: 20px;
   margin-left: 10px;
   margin-right: 10px;
+  cursor: pointer;
 `;

--- a/src/styles/theme.tsx
+++ b/src/styles/theme.tsx
@@ -77,6 +77,7 @@ export const SelectedFile = styled.div<selected>`
   border-color: #007fd4;
   border-width: ${(props) =>
     props.selectedAssemblyFile === props.element ? "1px" : "0px"};
+  cursor: pointer;
 `;
 
 export const NoneDragImg = styled.img`


### PR DESCRIPTION
클릭 가능한 이미지, 텍스트 등에 대하여 마우스 모양 변경

## ISSUE <#33>  마우스 모양 변경
클릭 가능한 이미지, 텍스트 등에 대하여 마우스 모양 변경


<br>

## CHANGES
클릭 가능한 텍스트 이미지에 대해서 스타일 옵션에 'cursor: pointer' 옵션 추가


<br>

## TEST
npm start 이후에 클릭 가능한 요소에 마우스 대보기

## EX
예시 사진이 있다면 여기에 첨부해주세요
